### PR TITLE
Use new Cypher queries in schema generator

### DIFF
--- a/scripts/mapNodes.cypher
+++ b/scripts/mapNodes.cypher
@@ -1,0 +1,9 @@
+MATCH (n)
+WHERE NOT n:Metagraph
+WITH labels(n) as LABELS, keys(n) as KEYS
+MERGE (m:Metagraph {metaType: 'NodeType', labels: LABELS})
+SET m.properties =
+CASE m.properties
+	WHEN NULL THEN KEYS
+    ELSE apoc.coll.union(m.properties, KEYS)
+END

--- a/scripts/mapRelationships.cypher
+++ b/scripts/mapRelationships.cypher
@@ -1,0 +1,11 @@
+MATCH (n)-[r]->(m)
+WHERE NOT n:Metagraph AND NOT m:Metagraph
+WITH labels(n) as start_labels, type(r) as rel_type, keys(r) as rel_keys, labels(m) as end_labels
+MERGE (a:Metagraph {metaType:'NodeType', labels: start_labels})
+MERGE (b:Metagraph {metaType:'NodeType', labels: end_labels})
+MERGE (a)<-[:StartNodeType]-(rel:Metagraph {metaType: 'RelType', type:rel_type })-[:EndNodeType]->(b)
+SET rel.properties =
+CASE rel_keys
+	WHEN NULL THEN []
+    ELSE rel_keys
+END


### PR DESCRIPTION
This solves the issue of duplicate nodes in the metagraph and greatly reduces the number of lines of code.