### PR TITLE
Configure URLs dynamically based on context-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Neo4j
 
-Project to develop Neo4j as the backing store for InterMine. This repository contains following two sub-projects.
+Project to develop Neo4j as the backing store for InterMine. Hosted on Heroku at http://intermine-neo4jwebapp.herokuapp.com/.
+
+This repository contains following two sub-projects.
 
 - **intermine-neo4j** contains the packages for Neo4j metadata management, PathQuery to Cypher conversion and data loaders for InterMine Neo4j database.
 
@@ -53,9 +55,9 @@ To run the project you need to get the following prerequisites.
 - To run a local instance of the server, run
 `./gradlew jettyRun`
 
-- For Swagger documentation of the API, visit http://localhost:8080/intermine-neo4jwebapp/.
+- For Swagger documentation of the API, visit http://localhost:8080/.
 
-- For testing PathQueryServlets, visit http://localhost:8080/intermine-neo4jwebapp/servlet/.
+- For testing PathQueryServlets, visit http://localhost:8080/servlet/.
 
 ## Documentation
 

--- a/intermine-neo4jwebapp/build.gradle
+++ b/intermine-neo4jwebapp/build.gradle
@@ -51,3 +51,5 @@ dependencies {
 httpPort = 8080
 stopPort = 9451
 stopKey = 'foo'
+
+jettyRun.contextPath = ''

--- a/intermine-neo4jwebapp/src/main/webapp/WEB-INF/web.xml
+++ b/intermine-neo4jwebapp/src/main/webapp/WEB-INF/web.xml
@@ -97,7 +97,7 @@
         </init-param>
         <init-param>
             <param-name>swagger.api.basepath</param-name>
-            <param-value>http://localhost:8080/intermine-neo4jwebapp/service</param-value>
+            <param-value>/service</param-value>
         </init-param>
         <load-on-startup>2</load-on-startup>
     </servlet>

--- a/intermine-neo4jwebapp/src/main/webapp/index.html
+++ b/intermine-neo4jwebapp/src/main/webapp/index.html
@@ -74,7 +74,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://localhost:8080/intermine-neo4jwebapp/service/swagger.json",
+    url: window.location.href + "service/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/intermine-neo4jwebapp/src/test/java/Test.java
+++ b/intermine-neo4jwebapp/src/test/java/Test.java
@@ -29,8 +29,9 @@ public class Test {
 
         cypherQuery.setResultRowsLimit(10);
         System.out.println("result limit set");
-        QueryResult queryResult = new Neo4jQueryService().getResultsFromNeo4j(props.getGraphDatabaseDriver(),
-                cypherQuery, pathQuery);
+        QueryResult queryResult = new QueryResult();
+        queryResult.setResults(new Neo4jQueryService().getResultsFromNeo4j(props.getGraphDatabaseDriver(),
+                                                                        cypherQuery, pathQuery));
         System.out.println(queryResult.toJSON());
     }
 


### PR DESCRIPTION
Earlier URLs of swagger.json in index.html and swagger.api.basepath in web.xml were hardcoded. Now they are set as per the context root of the web application. This will make it easier to deploy on any server.