### PR TITLE
Load java.util.Date attribute as "string" in Neo4j

### DIFF
--- a/intermine-neo4j/src/main/java/org/intermine/neo4j/Neo4jEdgeLoader.java
+++ b/intermine-neo4j/src/main/java/org/intermine/neo4j/Neo4jEdgeLoader.java
@@ -225,7 +225,8 @@ public class Neo4jEdgeLoader {
                         } else {
                             set += ", ";
                         }
-                        if (attrType.equals("java.lang.String") || attrType.equals("org.intermine.objectstore.query.ClobAccess")) {
+                        if (attrType.equals("java.lang.String") || attrType.equals("java.util.Date")
+                                || attrType.equals("org.intermine.objectstore.query.ClobAccess")) {
                             set += "r."+attrName+"=\""+val+"\"";
                         } else {
                             set += "r."+attrName+"="+val;

--- a/intermine-neo4j/src/main/java/org/intermine/neo4j/Neo4jLoader.java
+++ b/intermine-neo4j/src/main/java/org/intermine/neo4j/Neo4jLoader.java
@@ -348,7 +348,8 @@ public class Neo4jLoader {
                         String val = escapeForNeo4j(row[i++].toString());
                         terms++;
                         if (terms>1) match += ",";
-                        if (attrType.equals("java.lang.String") || attrType.equals("org.intermine.objectstore.query.ClobAccess")) {
+                        if (attrType.equals("java.lang.String") || attrType.equals("java.util.Date")
+                                || attrType.equals("org.intermine.objectstore.query.ClobAccess")) {
                             match += "n."+attrName+"=\""+val+"\"";
                         } else {
                             match += "n."+attrName+"="+val;


### PR DESCRIPTION
Not sure why, but my very minor code changes in PR #14 (which was merged successfully) don't seem to be reflected in the re-organized code base (after implementation of Gradle).

The following PR ensures that any IM attributes of type `java.util.Date` are converted to String before storing in Neo4j.

The ThaleMine data model has a few Entities with attributes containing date/time stamps, that make use of this particular type. I test loaded some data from ThaleMine into a local Neo4j instance today and encountered an error, which prompted me to make this change again.

Otherwise, all other aspects of the loader work very well against the ThaleMine/MedicMine data model!